### PR TITLE
Fix device import paths

### DIFF
--- a/src/roborock.ts
+++ b/src/roborock.ts
@@ -1,5 +1,5 @@
 import * as miio from 'miio';
-import { RoboticVacuumCleaner } from 'matterbridge';
+import { RoboticVacuumCleaner } from 'matterbridge/devices';
 import { RvcRunMode, RvcCleanMode, ServiceArea, RvcOperationalState, PowerSource } from 'matterbridge/matter/clusters';
 
 import { runModes, cleanModes, serviceAreas, stateToOperationalStateMap, operationalErrorMap, ErrorCode } from './constants.js';


### PR DESCRIPTION
## Summary
- update `RoboticVacuumCleaner` import to use `matterbridge/devices`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68690f306414832baab42a8b6a050b83