### PR TITLE
Use real serial number during discovery

### DIFF
--- a/src/miio.d.ts
+++ b/src/miio.d.ts
@@ -42,6 +42,10 @@ declare module 'miio' {
     status_info: InitStatusStatusInfo;
   }
 
+  export interface SerialNumberResult {
+    serial_number: string;
+  }
+
   export interface VacuumProperties {
     state:
       | 'initiating'


### PR DESCRIPTION
## Summary
- fetch serial number via `get_serial_number` and use it when instantiating the vacuum
- add `SerialNumberResult` interface to miio types

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697d9cd8a4832bb0cf4fb76d9c8a00